### PR TITLE
Added the ability to specify the amount of text to extract and index from an attachment.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,22 @@
     </properties>
 
     <repositories>
+     <repository>
+          <id>codehausSnapshots</id>
+          <name>Codehaus Snapshots</name>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+            <checksumPolicy>warn</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
+          </snapshots>
+          <url>http://oss.sonatype.org/content/repositories/releases/</url>
+          <layout>default</layout>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -90,6 +106,7 @@
                     <include>**/*.json</include>
                     <include>**/*.yml</include>
                     <include>**/*.html</include>
+                    <include>**/*.txt</include>
                 </includes>
             </testResource>
         </testResources>

--- a/src/test/java/org/elasticsearch/index/mapper/xcontent/testContentLength.txt
+++ b/src/test/java/org/elasticsearch/index/mapper/xcontent/testContentLength.txt
@@ -1,0 +1,9 @@
+Begin
+
+BeforeLimit AfterLimit
+
+Broadway
+
+Nearing the end
+
+End


### PR DESCRIPTION
By default, tika is only extracting a maximum of 100,000 characters from the uploaded file attachment. I have modified it so that on upload, you can specify the maximum amount of characters to extract from the document (specify -1 to remove any limit). 

Example usage:
{
    "my_attachment" : {
        "_content_length" : 500000,
        "_content_type" : "application/pdf",
        "_name" : "resource/name/of/my.pdf",
        "content" : "... base64 encoded attachment ..." 
}
}
