### PR TITLE
Log tika exceptions

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/attachment/AttachmentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/attachment/AttachmentMapper.java
@@ -385,7 +385,11 @@ public class AttachmentMapper implements Mapper {
             parsedContent = tika().parseToString(new BytesStreamInput(content, false), metadata, indexedChars);
         } catch (Throwable e) {
             // #18: we could ignore errors when Tika does not parse data
-            if (!ignoreErrors) throw new MapperParsingException("Failed to extract [" + indexedChars + "] characters of text for [" + name + "]", e);
+            if (!ignoreErrors) {
+                throw new MapperParsingException("Failed to extract [" + indexedChars + "] characters of text for [" + name + "]", e);
+            } else {
+                logger.warn("Failed to extract [" + indexedChars + "] characters of text for [" + name + "]", e.getMessage());
+            }
             return;
         }
 


### PR DESCRIPTION
Currently tika exceptions are swallowed with no log message. We'd like to be able to know when/if this occurs and for what reason.
