### PR TITLE
Exclude jhighlight dependency, which contains LGPL-only files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
                     <groupId>edu.ucar</groupId>
                     <artifactId>netcdf</artifactId>
                 </exclusion>
+                <!-- Not Apache2 License compatible -->
+                <exclusion>
+                    <groupId>com.uwyn</groupId>
+                    <artifactId>jhighlight</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Fix for #115