### PR TITLE
parse java.specification.version not java.version, so that it is robust

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/mapper/attachments/tika/LocaleChecker.java
+++ b/src/main/java/org/elasticsearch/plugin/mapper/attachments/tika/LocaleChecker.java
@@ -33,7 +33,7 @@ public class LocaleChecker {
     public static int JVM_PATCH_MINOR_VERSION = 0;
 
     static {
-        StringTokenizer st = new StringTokenizer(Constants.JAVA_VERSION, ".");
+        StringTokenizer st = new StringTokenizer(Constants.JVM_SPEC_VERSION, ".");
         JVM_MAJOR_VERSION = parseInt(st.nextToken());
         if(st.hasMoreTokens()) {
             JVM_MINOR_VERSION = parseInt(st.nextToken());


### PR DESCRIPTION
Fixes #116

This is the same logic lucene is using and should be robust across other jvms, too.