### PR TITLE
Don't wrap exceptions in `MapperParsingException`

### DIFF
--- a/src/main/java/org/elasticsearch/index/mapper/attachment/AttachmentMapper.java
+++ b/src/main/java/org/elasticsearch/index/mapper/attachment/AttachmentMapper.java
@@ -451,7 +451,9 @@ public class AttachmentMapper extends AbstractFieldMapper<Object> {
 
             // #18: we could ignore errors when Tika does not parse data
             if (!ignoreErrors) {
-                throw new MapperParsingException("Failed to extract [" + indexedChars + "] characters of text for [" + name + "]", e);
+                logger.trace("exception caught", e);
+                throw new MapperParsingException("Failed to extract [" + indexedChars + "] characters of text for [" + name + "] : "
+                        + e.getMessage());
             } else {
                 logger.debug("Failed to extract [{}] characters of text for [{}]: [{}]", indexedChars, name, e.getMessage());
                 logger.trace("exception caught", e);


### PR DESCRIPTION
Some exceptions might not be serializable. It would be safer not to wrap them in a `MapperParsingException` but just create the `MapperParsingException`.

Related to #113.