### PR TITLE
Remove all netcdf dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers</artifactId>
-            <version>1.8</version>
+            <version>1.10</version>
             <exclusions>
                 <!-- Not Apache2 License compatible -->
                 <exclusion>
@@ -66,8 +66,37 @@
                 </exclusion>
                 <!-- Not Apache2 License compatible -->
                 <exclusion>
+                    <groupId>edu.ucar</groupId>
+                    <artifactId>cdm</artifactId>
+                </exclusion>
+                <!-- Not Apache2 License compatible -->
+                <exclusion>
+                    <groupId>edu.ucar</groupId>
+                    <artifactId>httpservices</artifactId>
+                </exclusion>
+                <!-- Not Apache2 License compatible -->
+                <exclusion>
+                    <groupId>edu.ucar</groupId>
+                    <artifactId>grib</artifactId>
+                </exclusion>
+                <!-- Not Apache2 License compatible -->
+                <exclusion>
+                    <groupId>edu.ucar</groupId>
+                    <artifactId>netcdf4</artifactId>
+                </exclusion>
+                <!-- Not Apache2 License compatible -->
+                <exclusion>
                     <groupId>com.uwyn</groupId>
                     <artifactId>jhighlight</artifactId>
+                </exclusion>
+                <!-- ES core already has these -->
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-debug-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Follow up for #84.

Sounds like that httpcore is pulled by netcdf libs. Note that we wrote in #84 that we were removing support for netcdf file types.

```xml
<!-- Not Apache2 License compatible -->
<exclusion>
    <groupId>edu.ucar</groupId>
    <artifactId>netcdf</artifactId>
</exclusion>
```

Apparently the removal was not entirely done.

Adding exclusion the following exclusions will fix that:

```xml
<!-- Not Apache2 License compatible -->
<exclusion>
    <groupId>edu.ucar</groupId>
    <artifactId>cdm</artifactId>
</exclusion>
<!-- Not Apache2 License compatible -->
<exclusion>
    <groupId>edu.ucar</groupId>
    <artifactId>httpservices</artifactId>
</exclusion>
<!-- Not Apache2 License compatible -->
<exclusion>
    <groupId>edu.ucar</groupId>
    <artifactId>grib</artifactId>
</exclusion>
<!-- Not Apache2 License compatible -->
<exclusion>
    <groupId>edu.ucar</groupId>
    <artifactId>netcdf4</artifactId>
</exclusion>
```

With that, we don't pull anymore http* client/core/component libs:

```
[INFO] org.elasticsearch:elasticsearch-mapper-attachments:jar:2.7.1-SNAPSHOT
...
[INFO] +- org.apache.tika:tika-parsers:jar:1.10:compile
[INFO] |  +- org.apache.tika:tika-core:jar:1.10:compile
[INFO] |  +- org.gagravarr:vorbis-java-tika:jar:0.6:compile
[INFO] |  +- com.healthmarketscience.jackcess:jackcess:jar:2.1.2:compile
[INFO] |  |  +- commons-lang:commons-lang:jar:2.6:compile
[INFO] |  |  \- commons-logging:commons-logging:jar:1.1.3:compile
[INFO] |  +- com.healthmarketscience.jackcess:jackcess-encrypt:jar:2.1.0:compile
[INFO] |  +- net.sourceforge.jmatio:jmatio:jar:1.0:compile
[INFO] |  +- org.apache.james:apache-mime4j-core:jar:0.7.2:compile
[INFO] |  +- org.apache.james:apache-mime4j-dom:jar:0.7.2:compile
[INFO] |  +- org.apache.commons:commons-compress:jar:1.9:compile
[INFO] |  +- org.tukaani:xz:jar:1.5:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.9:compile
[INFO] |  +- org.apache.pdfbox:pdfbox:jar:1.8.10:compile
[INFO] |  |  +- org.apache.pdfbox:fontbox:jar:1.8.10:compile
[INFO] |  |  \- org.apache.pdfbox:jempbox:jar:1.8.10:compile
[INFO] |  +- org.bouncycastle:bcmail-jdk15on:jar:1.52:compile
[INFO] |  |  \- org.bouncycastle:bcpkix-jdk15on:jar:1.52:compile
[INFO] |  +- org.bouncycastle:bcprov-jdk15on:jar:1.52:compile
[INFO] |  +- org.apache.poi:poi:jar:3.13-beta1:compile
[INFO] |  +- org.apache.poi:poi-scratchpad:jar:3.13-beta1:compile
[INFO] |  +- org.apache.poi:poi-ooxml:jar:3.13-beta1:compile
[INFO] |  |  \- org.apache.poi:poi-ooxml-schemas:jar:3.13-beta1:compile
[INFO] |  |     \- org.apache.xmlbeans:xmlbeans:jar:2.6.0:compile
[INFO] |  +- org.ccil.cowan.tagsoup:tagsoup:jar:1.2.1:compile
[INFO] |  +- com.googlecode.mp4parser:isoparser:jar:1.0.2:compile
[INFO] |  |  \- org.aspectj:aspectjrt:jar:1.8.0:compile
[INFO] |  +- com.drewnoakes:metadata-extractor:jar:2.8.0:compile
[INFO] |  |  \- com.adobe.xmp:xmpcore:jar:5.1.2:compile
[INFO] |  +- de.l3s.boilerpipe:boilerpipe:jar:1.1.0:compile
[INFO] |  +- rome:rome:jar:1.0:compile
[INFO] |  |  \- jdom:jdom:jar:1.0:compile
[INFO] |  +- org.gagravarr:vorbis-java-core:jar:0.6:compile
[INFO] |  +- com.googlecode.juniversalchardet:juniversalchardet:jar:1.0.3:compile
[INFO] |  +- org.codelibs:jhighlight:jar:1.0.2:compile
[INFO] |  +- com.pff:java-libpst:jar:0.8.1:compile
[INFO] |  +- com.github.junrar:junrar:jar:0.7:compile
[INFO] |  |  \- org.apache.commons:commons-vfs2:jar:2.0:compile
[INFO] |  |     +- org.apache.maven.scm:maven-scm-api:jar:1.4:compile
[INFO] |  |     |  \- org.codehaus.plexus:plexus-utils:jar:1.5.6:compile
[INFO] |  |     \- org.apache.maven.scm:maven-scm-provider-svnexe:jar:1.4:compile
[INFO] |  |        +- org.apache.maven.scm:maven-scm-provider-svn-commons:jar:1.4:compile
[INFO] |  |        \- regexp:regexp:jar:1.3:compile
[INFO] |  +- org.apache.opennlp:opennlp-tools:jar:1.5.3:compile
[INFO] |  |  +- org.apache.opennlp:opennlp-maxent:jar:3.0.3:compile
[INFO] |  |  \- net.sf.jwordnet:jwnl:jar:1.3.3:compile
[INFO] |  +- commons-io:commons-io:jar:2.4:compile
[INFO] |  +- org.apache.commons:commons-exec:jar:1.3:compile
[INFO] |  +- com.googlecode.json-simple:json-simple:jar:1.1.1:compile
[INFO] |  +- com.google.guava:guava:jar:18.0:compile
[INFO] |  +- org.apache.commons:commons-csv:jar:1.0:compile
[INFO] |  +- org.apache.sis.core:sis-utility:jar:0.5:compile
[INFO] |  +- org.apache.sis.storage:sis-netcdf:jar:0.5:compile
[INFO] |  |  +- org.apache.sis.storage:sis-storage:jar:0.5:compile
[INFO] |  |  \- org.apache.sis.core:sis-referencing:jar:0.5:compile
[INFO] |  +- org.apache.sis.core:sis-metadata:jar:0.5:compile
[INFO] |  \- org.opengis:geoapi:jar:3.0.0:compile
[INFO] |     \- javax.measure:jsr-275:jar:0.9.3:compile
[INFO] +- log4j:log4j:jar:1.2.17:compile
[INFO] \- org.elasticsearch:elasticsearch:test-jar:tests:1.7.0:test
```

Closes #157