### PR TITLE
Lockdown parsers with minimal privileges

### DIFF
--- a/src/main/java/org/elasticsearch/mapper/attachments/TikaImpl.java
+++ b/src/main/java/org/elasticsearch/mapper/attachments/TikaImpl.java
@@ -1,9 +1,42 @@
 package org.elasticsearch.mapper.attachments;
 
+import java.io.ByteArrayInputStream;
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.FilePermission;
 import java.io.IOException;
+import java.lang.reflect.ReflectPermission;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.security.AccessControlContext;
 import java.security.AccessController;
+import java.security.PermissionCollection;
+import java.security.Permissions;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.security.ProtectionDomain;
+import java.security.SecurityPermission;
+import java.util.PropertyPermission;
 
 import org.apache.tika.Tika;
 import org.apache.tika.exception.TikaException;
@@ -11,11 +44,17 @@ import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.Parser;
 import org.elasticsearch.SpecialPermission;
-import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.bootstrap.JarHell;
+import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.io.PathUtils;
 
-/** do NOT make public */
+/**
+ * Runs tika with limited parsers and limited permissions.
+ * <p>
+ * Do NOT make public
+ */
 final class TikaImpl {
-   
+
     /** subset of parsers for types we support */
     private static final Parser PARSERS[] = new Parser[] {
         // documents
@@ -52,9 +91,9 @@ final class TikaImpl {
             return AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
                 @Override
                 public String run() throws TikaException, IOException {
-                    return TIKA_INSTANCE.parseToString(StreamInput.wrap(content), metadata, limit);
+                    return TIKA_INSTANCE.parseToString(new ByteArrayInputStream(content), metadata, limit);
                 }
-            });
+            }, RESTRICTED_CONTEXT);
         } catch (PrivilegedActionException e) {
             // checked exception from tika: unbox it
             Throwable cause = e.getCause();
@@ -65,6 +104,56 @@ final class TikaImpl {
             } else {
                 throw new AssertionError(cause);
             }
+        }
+    }
+
+    // apply additional containment for parsers, this is intersected with the current permissions
+    // its hairy, but worth it so we don't have some XML flaw reading random crap from the FS
+    private static final AccessControlContext RESTRICTED_CONTEXT = new AccessControlContext(
+        new ProtectionDomain[] {
+            new ProtectionDomain(null, getRestrictedPermissions())
+        }
+    );
+
+    // compute some minimal permissions for parsers. they only get r/w access to the java temp directory,
+    // the ability to load some resources from JARs, and read sysprops
+    static PermissionCollection getRestrictedPermissions() {
+        Permissions perms = new Permissions();
+        // property/env access needed for parsing
+        perms.add(new PropertyPermission("*", "read"));
+        perms.add(new RuntimePermission("getenv.TIKA_CONFIG"));
+
+        // add permissions for resource access:
+        // classpath
+        addReadPermissions(perms, JarHell.parseClassPath());
+        // plugin jars
+        if (TikaImpl.class.getClassLoader() instanceof URLClassLoader) {
+            addReadPermissions(perms, ((URLClassLoader)TikaImpl.class.getClassLoader()).getURLs());
+        }
+        // jvm's java.io.tmpdir (needs read/write)
+        perms.add(new FilePermission(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator") + "-",
+                                     "read,readlink,write,delete"));
+        // current hacks needed for POI/PDFbox issues:
+        perms.add(new SecurityPermission("putProviderProperty.BC"));
+        perms.add(new SecurityPermission("insertProvider"));
+        perms.add(new ReflectPermission("suppressAccessChecks"));
+        perms.setReadOnly();
+        return perms;
+    }
+
+    // add resources to (what is typically) a jar, but might not be (e.g. in tests/IDE)
+    @SuppressForbidden(reason = "adds access to jar resources")
+    static void addReadPermissions(Permissions perms, URL resources[]) {
+        try {
+            for (URL url : resources) {
+                Path path = PathUtils.get(url.toURI());
+                // resource itself
+                perms.add(new FilePermission(path.toString(), "read,readlink"));
+                // classes underneath
+                perms.add(new FilePermission(path.toString() + System.getProperty("file.separator") + "-", "read,readlink"));
+            }
+        } catch (URISyntaxException bogus) {
+            throw new RuntimeException(bogus);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/mapper/attachments/TikaImpl.java
+++ b/src/main/java/org/elasticsearch/mapper/attachments/TikaImpl.java
@@ -1,7 +1,5 @@
 package org.elasticsearch.mapper.attachments;
 
-import java.io.ByteArrayInputStream;
-
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -21,6 +19,7 @@ import java.io.ByteArrayInputStream;
  * under the License.
  */
 
+import java.io.ByteArrayInputStream;
 import java.io.FilePermission;
 import java.io.IOException;
 import java.lang.reflect.ReflectPermission;

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -17,8 +17,12 @@
  * under the License.
  */
 
+// NOTE: when modifying this file, look at restrictions in TikaImpl too
 grant {
-  // TODO: fix tika not to actually install bouncy castle like this
+  // needed to apply additional sandboxing to tika parsing
+  permission java.security.SecurityPermission "createAccessControlContext";
+
+  // TODO: fix PDFBox not to actually install bouncy castle like this
   permission java.security.SecurityPermission "putProviderProperty.BC";
   permission java.security.SecurityPermission "insertProvider";
   // TODO: fix POI XWPF to not do this: https://bz.apache.org/bugzilla/show_bug.cgi?id=58597


### PR DESCRIPTION
There have been security issues with tika's parsers in the past...
let's take away the network, filesystem, everything we can.

In some way, parsing these docs is a lot like executing untrusted code.

I know its not pretty, but I think its worth it.